### PR TITLE
Output Struct should implement Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_PRIMORIAL_OFFSETS: &'static [(&'static [isize], u128)] = &[
 ];
 
 // Struct for results of interest found by a Stella instance (actual prime k-tuplet, long enough tuple, or pool share).
+#[derive(Clone)]
 pub struct Output {
 	pub n: Integer,
 	pub k: usize,


### PR DESCRIPTION
I am in the process of adding a Stella instance in the Miner struct and having the output implement clone would help. I don't see any downsides in doing so.